### PR TITLE
Align Compose toolchain and adopt AndroidX placeholder

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,28 +27,50 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
-        viewBinding = true
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
 }
 
 dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.09.02")
 
-    implementation("androidx.core:core-ktx:1.17.0")
-    implementation("androidx.appcompat:appcompat:1.7.1")
-    implementation("com.google.android.material:material:1.13.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.9.4")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.4")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.9.4")
-    implementation("androidx.navigation:navigation-ui-ktx:2.9.4")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.6")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.material:material-pull-refresh")
+    implementation("androidx.compose.foundation:foundation-layout")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 }

--- a/app/src/main/java/com/example/ambis/MainActivity.kt
+++ b/app/src/main/java/com/example/ambis/MainActivity.kt
@@ -1,35 +1,69 @@
 package com.example.ambis
 
 import android.os.Bundle
-import com.google.android.material.bottomnavigation.BottomNavigationView
-import androidx.appcompat.app.AppCompatActivity
-import androidx.navigation.findNavController
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.setupActionBarWithNavController
-import androidx.navigation.ui.setupWithNavController
-import com.example.ambis.databinding.ActivityMainBinding
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.ambis.home.HomeRoute
+import com.example.ambis.home.HomeViewModel
+import com.example.ambis.ui.theme.AmbisTheme
+import com.example.ambis.util.findActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
-    private lateinit var binding: ActivityMainBinding
+    private val viewModel: HomeViewModel by viewModels { HomeViewModel.Factory(applicationContext) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContent {
+            AmbisTheme {
+                val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+                val refreshing by viewModel.refreshing.collectAsStateWithLifecycle()
 
-        binding = ActivityMainBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+                SecureWindowEffect(showSecure = (uiState as? com.example.ambis.home.HomeUiState.Loaded)?.visible == true)
 
-        val navView: BottomNavigationView = binding.navView
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    HomeRoute(
+                        state = uiState,
+                        refreshing = refreshing,
+                        onToggleVisible = viewModel::toggleBalanceVisibility,
+                        onNavigate = viewModel::onNavigate,
+                        onRefresh = { viewModel.refresh(force = true) }
+                    )
+                }
+            }
+        }
+    }
+}
 
-        val navController = findNavController(R.id.nav_host_fragment_activity_main)
-        // Passing each menu ID as a set of Ids because each
-        // menu should be considered as top level destinations.
-        val appBarConfiguration = AppBarConfiguration(
-            setOf(
-                R.id.navigation_home, R.id.navigation_dashboard, R.id.navigation_notifications
-            )
-        )
-        setupActionBarWithNavController(navController, appBarConfiguration)
-        navView.setupWithNavController(navController)
+@Composable
+private fun SecureWindowEffect(showSecure: Boolean) {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    DisposableEffect(showSecure, activity) {
+        activity?.window?.let { window ->
+            if (showSecure) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            } else {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
+        }
+        onDispose {
+            if (showSecure) {
+                activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/ambis/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ambis/home/HomeScreen.kt
@@ -1,0 +1,628 @@
+package com.example.ambis.home
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.with
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.placeholder.PlaceholderHighlight
+import androidx.compose.foundation.placeholder.PlaceholderHighlight.Companion.shimmer
+import androidx.compose.foundation.placeholder.placeholder
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.CreditCard
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.ElevatedAssistChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.ambis.model.ActionItem
+import com.example.ambis.model.Dest
+import com.example.ambis.model.ServiceItem
+import java.text.NumberFormat
+import java.util.Locale
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun HomeRoute(
+    state: HomeUiState,
+    refreshing: Boolean,
+    onToggleVisible: () -> Unit,
+    onNavigate: (Dest) -> Unit,
+    onRefresh: () -> Unit
+) {
+    val pullRefreshState = rememberPullRefreshState(refreshing = refreshing, onRefresh = onRefresh)
+
+    Scaffold(
+        topBar = {
+            HomeTopBar(
+                hasUnreadNotifications = (state as? HomeUiState.Loaded)?.hasUnread == true,
+                onNotifications = { onNavigate(Dest.Notifications) }
+            )
+        },
+        bottomBar = {
+            HomeBottomBar(current = Dest.Home, onNavigate = onNavigate)
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .pullRefresh(pullRefreshState)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            when (state) {
+                HomeUiState.Loading -> HomeSkeleton()
+                is HomeUiState.Error -> HomeError(message = state.message, onRetry = onRefresh)
+                HomeUiState.Offline -> OfflineNotice(onRetry = onRefresh)
+                is HomeUiState.Loaded -> HomeContent(
+                    state = state,
+                    onToggleVisible = onToggleVisible,
+                    onNavigate = onNavigate
+                )
+            }
+
+            PullRefreshIndicator(
+                refreshing = refreshing,
+                state = pullRefreshState,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeContent(
+    state: HomeUiState.Loaded,
+    onToggleVisible: () -> Unit,
+    onNavigate: (Dest) -> Unit
+) {
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            BalanceCard(
+                company = state.company,
+                balance = state.balance,
+                visible = state.visible,
+                hasAccounts = state.quick.isNotEmpty(),
+                quickActions = state.quick,
+                onToggleVisible = onToggleVisible,
+                onManageAccounts = { onNavigate(Dest.ManageAccounts) },
+                onQuickAction = { action -> onNavigate(Dest.QuickAction(action.id)) }
+            )
+        }
+        item {
+            ApprovalCard(
+                pending = state.pending,
+                onAll = { onNavigate(Dest.ApprovalsPending) },
+                onDone = { onNavigate(Dest.ApprovalsDone) }
+            )
+        }
+        item {
+            BillsSection(
+                services = state.services,
+                onService = { service -> onNavigate(Dest.Service(service.id)) },
+                onHistory = { onNavigate(Dest.BillsHistory) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeTopBar(
+    hasUnreadNotifications: Boolean,
+    onNotifications: () -> Unit
+) {
+    Surface(color = MaterialTheme.colorScheme.primary) {
+        Row(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "amar bank",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
+                )
+                Text(
+                    text = "bisnis",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            BadgedBox(
+                badge = {
+                    if (hasUnreadNotifications) {
+                        Badge(containerColor = MaterialTheme.colorScheme.error)
+                    }
+                }
+            ) {
+                IconButton(onClick = onNotifications) {
+                    Icon(
+                        imageVector = Icons.Outlined.Notifications,
+                        contentDescription = "Notifikasi",
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeBottomBar(
+    current: Dest,
+    onNavigate: (Dest) -> Unit
+) {
+    NavigationBar {
+        NavigationBarItem(
+            selected = current == Dest.Home,
+            onClick = { },
+            enabled = false,
+            icon = { Icon(Icons.Outlined.Home, contentDescription = "Beranda") },
+            label = { Text("Beranda") }
+        )
+        NavigationBarItem(
+            selected = current == Dest.Profile,
+            onClick = { onNavigate(Dest.Profile) },
+            icon = { Icon(Icons.Outlined.AccountCircle, contentDescription = "Profil") },
+            label = { Text("Profil") }
+        )
+        NavigationBarItem(
+            selected = current == Dest.Vault,
+            onClick = { onNavigate(Dest.Vault) },
+            icon = { Icon(Icons.Outlined.CreditCard, contentDescription = "Brankas") },
+            label = { Text("Brankas") }
+        )
+        NavigationBarItem(
+            selected = current == Dest.More,
+            onClick = { onNavigate(Dest.More) },
+            icon = { Icon(Icons.Outlined.Menu, contentDescription = "Lainnya") },
+            label = { Text("Lainnya") }
+        )
+    }
+}
+
+@Composable
+private fun BalanceCard(
+    company: String,
+    balance: Long,
+    visible: Boolean,
+    hasAccounts: Boolean,
+    quickActions: List<ActionItem>,
+    onToggleVisible: () -> Unit,
+    onManageAccounts: () -> Unit,
+    onQuickAction: (ActionItem) -> Unit
+) {
+    val currencyFormatter = remember {
+        NumberFormat.getCurrencyInstance(Locale("id", "ID")).apply {
+            maximumFractionDigits = 0
+        }
+    }
+
+    Surface(
+        tonalElevation = 6.dp,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            AssistChip(
+                onClick = {},
+                enabled = false,
+                label = {
+                    Text(
+                        text = company,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Total Saldo Aktif",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = "Seluruh dana rekening",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                IconButton(onClick = onToggleVisible) {
+                    val icon = if (visible) Icons.Outlined.Visibility else Icons.Outlined.VisibilityOff
+                    val desc = if (visible) "Sembunyikan saldo" else "Tampilkan saldo"
+                    Icon(imageVector = icon, contentDescription = desc)
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            AnimatedContent(
+                targetState = visible,
+                transitionSpec = { fadeIn(animationSpec = tween(200)) with fadeOut(animationSpec = tween(200)) },
+                label = "balanceVisibility"
+            ) { isVisible ->
+                val display = if (isVisible) currencyFormatter.format(balance) else "Rp•••"
+                Text(
+                    text = display,
+                    style = MaterialTheme.typography.displaySmall,
+                    maxLines = 2,
+                    softWrap = true,
+                    modifier = Modifier.animateContentSize()
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            OutlinedButton(onClick = onManageAccounts) {
+                Text("Atur Semua Rekening")
+            }
+
+            if (hasAccounts) {
+                Spacer(modifier = Modifier.height(24.dp))
+                QuickActionsGrid(actions = quickActions, onQuickAction = onQuickAction)
+            } else {
+                Spacer(modifier = Modifier.height(24.dp))
+                EmptyAccountState(onAddAccount = onManageAccounts)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun QuickActionsGrid(
+    actions: List<ActionItem>,
+    onQuickAction: (ActionItem) -> Unit
+) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        maxItemsInEachRow = 4,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        actions.forEach { action ->
+            QuickActionTile(action = action, onClick = { onQuickAction(action) })
+        }
+    }
+}
+
+@Composable
+private fun QuickActionTile(action: ActionItem, onClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .semantics { contentDescription = action.label }
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 4.dp,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier
+                .size(72.dp)
+                .clickable(onClick = onClick)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = action.icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        }
+        Text(
+            text = action.label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            lineHeight = 16.sp
+        )
+    }
+}
+
+@Composable
+private fun EmptyAccountState(onAddAccount: () -> Unit) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "Belum ada rekening",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = "Tambahkan rekening terlebih dahulu untuk melihat saldo dan akses cepat.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedButton(onClick = onAddAccount) {
+                Text("Tambah Rekening")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApprovalCard(
+    pending: Int,
+    onAll: () -> Unit,
+    onDone: () -> Unit
+) {
+    Surface(
+        tonalElevation = 6.dp,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = pending.toString(),
+                        style = MaterialTheme.typography.displaySmall
+                    )
+                    Text(
+                        text = "Aktivitas Butuh Persetujuan Anda",
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
+                ElevatedAssistChip(
+                    onClick = onAll,
+                    label = { Text("Lihat Semua") }
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                tonalElevation = 2.dp
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onDone)
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.AccountBalance,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Lihat Aktivitas Selesai",
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Text(
+                            text = "Riwayat persetujuan yang sudah selesai",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BillsSection(
+    services: List<ServiceItem>,
+    onService: (ServiceItem) -> Unit,
+    onHistory: () -> Unit
+) {
+    Surface(
+        tonalElevation = 6.dp,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "Beli & Bayar",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                TextButton(onClick = onHistory) {
+                    Text(
+                        text = "Riwayat",
+                        textDecoration = TextDecoration.Underline
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            val tiles = services.take(3)
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                tiles.forEach { service ->
+                    ServiceTile(
+                        service = service,
+                        modifier = Modifier.weight(1f),
+                        onClick = { onService(service) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ServiceTile(service: ServiceItem, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 4.dp,
+        modifier = modifier
+            .heightIn(min = 112.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Icon(
+                imageVector = service.icon,
+                contentDescription = service.label,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+            Text(
+                text = service.label,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HomeSkeleton() {
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(3) {
+            Surface(
+                tonalElevation = 6.dp,
+                shape = MaterialTheme.shapes.large,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .placeholder(visible = true, highlight = PlaceholderHighlight.shimmer())
+            ) {}
+        }
+    }
+}
+
+@Composable
+private fun HomeError(message: String, onRetry: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(24.dp)
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center
+            )
+            OutlinedButton(onClick = onRetry) {
+                Text("Coba Lagi")
+            }
+        }
+    }
+}
+
+@Composable
+private fun OfflineNotice(onRetry: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(24.dp)
+        ) {
+            Text(
+                text = "Mode offline. Menampilkan data terakhir.",
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center
+            )
+            OutlinedButton(onClick = onRetry) {
+                Text("Muat Ulang")
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomePreview() {
+    HomeContent(
+        state = HomeUiState.Loaded(
+            company = "PT Sarana Pancing Indonesia",
+            balance = 100_000_000_000L,
+            visible = true,
+            pending = 8,
+            quick = SampleContent.quickActions,
+            services = SampleContent.services,
+            hasUnread = true
+        ),
+        onToggleVisible = {},
+        onNavigate = {}
+    )
+}

--- a/app/src/main/java/com/example/ambis/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/ambis/home/HomeUiState.kt
@@ -1,0 +1,22 @@
+package com.example.ambis.home
+
+import com.example.ambis.model.ActionItem
+import com.example.ambis.model.ServiceItem
+
+sealed interface HomeUiState {
+    data object Loading : HomeUiState
+
+    data class Loaded(
+        val company: String,
+        val balance: Long,
+        val visible: Boolean,
+        val pending: Int,
+        val quick: List<ActionItem>,
+        val services: List<ServiceItem>,
+        val hasUnread: Boolean
+    ) : HomeUiState
+
+    data class Error(val message: String) : HomeUiState
+
+    data object Offline : HomeUiState
+}

--- a/app/src/main/java/com/example/ambis/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/ambis/home/HomeViewModel.kt
@@ -1,0 +1,189 @@
+package com.example.ambis.home
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.AccountBalanceWallet
+import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material.icons.outlined.HealthAndSafety
+import androidx.compose.material.icons.outlined.ReceiptLong
+import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.outlined.Wifi
+import com.example.ambis.model.ActionItem
+import com.example.ambis.model.Dest
+import com.example.ambis.model.ServiceItem
+import java.io.IOException
+import java.time.Instant
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+private val Context.balancePreferences by preferencesDataStore(name = "balance_visibility")
+
+class HomeViewModel(
+    private val repository: HomeRepository,
+    private val visibilityRepository: BalanceVisibilityRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    private val _refreshing = MutableStateFlow(false)
+    val refreshing: StateFlow<Boolean> = _refreshing.asStateFlow()
+
+    private val _navigation = MutableSharedFlow<Dest>(extraBufferCapacity = 1)
+    val navigation = _navigation.asSharedFlow()
+
+    init {
+        observeVisibility()
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch(ioDispatcher) {
+            _uiState.value = HomeUiState.Loading
+            fetchData()
+        }
+    }
+
+    fun refresh(force: Boolean) {
+        viewModelScope.launch(ioDispatcher) {
+            _refreshing.value = true
+            fetchData(force)
+            _refreshing.value = false
+        }
+    }
+
+    fun toggleBalanceVisibility() {
+        val current = _uiState.value
+        if (current is HomeUiState.Loaded) {
+            viewModelScope.launch(ioDispatcher) {
+                visibilityRepository.setVisible(!current.visible)
+            }
+        }
+    }
+
+    fun onNavigate(dest: Dest) {
+        _navigation.tryEmit(dest)
+    }
+
+    private suspend fun fetchData(force: Boolean = false) {
+        try {
+            val payload = repository.fetchHomeData(force)
+            val visible = visibilityRepository.isVisible()
+            _uiState.value = HomeUiState.Loaded(
+                company = payload.companyDisplayName,
+                balance = payload.totalActiveBalance,
+                visible = visible,
+                pending = payload.pendingApprovalCount,
+                quick = payload.quickActions,
+                services = payload.services,
+                hasUnread = payload.hasUnreadNotifications
+            )
+        } catch (io: IOException) {
+            _uiState.value = HomeUiState.Offline
+        } catch (throwable: Throwable) {
+            _uiState.value = HomeUiState.Error(throwable.message ?: "Terjadi kesalahan")
+        }
+    }
+
+    private fun observeVisibility() {
+        viewModelScope.launch {
+            visibilityRepository.visibility.collectLatest { visible ->
+                val current = _uiState.value
+                if (current is HomeUiState.Loaded && current.visible != visible) {
+                    _uiState.value = current.copy(visible = visible)
+                }
+            }
+        }
+    }
+
+    class Factory(private val context: Context) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            val repository = HomeRepository()
+            val visibilityRepository = BalanceVisibilityRepository(context.balancePreferences)
+            return HomeViewModel(repository, visibilityRepository) as T
+        }
+    }
+}
+
+class HomeRepository {
+    suspend fun fetchHomeData(force: Boolean): HomePayload {
+        // In a real implementation, this would reach the network or database.
+        // For now we simply return cached/sample content.
+        return HomePayload.sample()
+    }
+}
+
+data class HomePayload(
+    val companyDisplayName: String,
+    val totalActiveBalance: Long,
+    val pendingApprovalCount: Int,
+    val quickActions: List<ActionItem>,
+    val services: List<ServiceItem>,
+    val hasUnreadNotifications: Boolean,
+    val lastUpdatedAt: Instant
+) {
+    companion object {
+        fun sample(): HomePayload {
+            return HomePayload(
+                companyDisplayName = "PT Sarana Pancing Indonesia",
+                totalActiveBalance = 100_000_000_000L,
+                pendingApprovalCount = 8,
+                quickActions = SampleContent.quickActions,
+                services = SampleContent.services,
+                hasUnreadNotifications = true,
+                lastUpdatedAt = Instant.now()
+            )
+        }
+    }
+}
+
+object SampleContent {
+    val quickActions: List<ActionItem> = listOf(
+        ActionItem(id = "topup", label = "Top Up\nSaldo", icon = Icons.Outlined.AccountBalanceWallet),
+        ActionItem(id = "history", label = "Riwayat\nTransaksi", icon = Icons.Outlined.ReceiptLong),
+        ActionItem(id = "add-account", label = "Tambah\nRekening", icon = Icons.Outlined.AccountBalance),
+        ActionItem(id = "transfer", label = "Transfer", icon = Icons.Outlined.Send)
+    )
+
+    val services: List<ServiceItem> = listOf(
+        ServiceItem(id = "pln", label = "Listrik PLN", icon = Icons.Outlined.Bolt),
+        ServiceItem(id = "internet", label = "Internet", icon = Icons.Outlined.Wifi),
+        ServiceItem(id = "bpjs", label = "BPJS", icon = Icons.Outlined.HealthAndSafety)
+    )
+}
+
+class BalanceVisibilityRepository(private val dataStore: DataStore<Preferences>) {
+
+    private val key = booleanPreferencesKey("is_visible")
+
+    val visibility: kotlinx.coroutines.flow.Flow<Boolean> = dataStore.data
+        .map { prefs -> prefs[key] ?: false }
+
+    suspend fun isVisible(): Boolean = visibility.first()
+
+    suspend fun setVisible(value: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[key] = value
+        }
+    }
+}

--- a/app/src/main/java/com/example/ambis/model/Models.kt
+++ b/app/src/main/java/com/example/ambis/model/Models.kt
@@ -1,0 +1,29 @@
+package com.example.ambis.model
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class ActionItem(
+    val id: String,
+    val label: String,
+    val icon: ImageVector
+)
+
+data class ServiceItem(
+    val id: String,
+    val label: String,
+    val icon: ImageVector
+)
+
+sealed interface Dest {
+    data object Home : Dest
+    data object Profile : Dest
+    data object Vault : Dest
+    data object More : Dest
+    data object Notifications : Dest
+    data object ManageAccounts : Dest
+    data object ApprovalsPending : Dest
+    data object ApprovalsDone : Dest
+    data object BillsHistory : Dest
+    data class Service(val id: String) : Dest
+    data class QuickAction(val id: String) : Dest
+}

--- a/app/src/main/java/com/example/ambis/ui/theme/AmbisTheme.kt
+++ b/app/src/main/java/com/example/ambis/ui/theme/AmbisTheme.kt
@@ -1,0 +1,93 @@
+package com.example.ambis.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF0053A1),
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFF0D274D),
+    onPrimaryContainer = Color(0xFFE0ECFF),
+    secondary = Color(0xFF546070),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFD7E3F7),
+    onSecondaryContainer = Color(0xFF111C2B),
+    tertiary = Color(0xFF386A20),
+    onTertiary = Color.White,
+    background = Color(0xFFF8F9FC),
+    onBackground = Color(0xFF1B1B1F),
+    surface = Color.White,
+    onSurface = Color(0xFF1B1B1F),
+    surfaceVariant = Color(0xFFE0E2EC),
+    onSurfaceVariant = Color(0xFF424753),
+    outline = Color(0xFF737680),
+    error = Color(0xFFBA1A1A),
+    onError = Color.White
+)
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFFACC7FF),
+    onPrimary = Color(0xFF002F65),
+    primaryContainer = Color(0xFF0D274D),
+    onPrimaryContainer = Color(0xFFE0ECFF),
+    secondary = Color(0xFFBBC7DB),
+    onSecondary = Color(0xFF243140),
+    secondaryContainer = Color(0xFF3B4858),
+    onSecondaryContainer = Color(0xFFD7E3F7),
+    tertiary = Color(0xFFA0D48A),
+    onTertiary = Color(0xFF063908),
+    background = Color(0xFF111318),
+    onBackground = Color(0xFFE2E2E6),
+    surface = Color(0xFF111318),
+    onSurface = Color(0xFFE2E2E6),
+    surfaceVariant = Color(0xFF434750),
+    onSurfaceVariant = Color(0xFFC4C6D0),
+    outline = Color(0xFF8E909B),
+    error = Color(0xFFFFB4AB),
+    onError = Color(0xFF690005)
+)
+
+private val AmbisShapes = Shapes(
+    extraSmall = RoundedCornerShape(8.dp),
+    small = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(24.dp),
+    extraLarge = RoundedCornerShape(28.dp)
+)
+
+private val AmbisTypography = Typography()
+
+@Composable
+fun AmbisTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (useDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        useDarkTheme -> DarkColors
+        else -> LightColors
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = AmbisTypography,
+        shapes = AmbisShapes,
+        content = content
+    )
+}

--- a/app/src/main/java/com/example/ambis/util/ContextExtensions.kt
+++ b/app/src/main/java/com/example/ambis/util/ContextExtensions.kt
@@ -1,0 +1,11 @@
+package com.example.ambis.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,16 +1,4 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Ambis" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
-    </style>
+    <style name="Theme.Ambis" parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Summary
- align the Android module with Compose BOM 2024.09.02, Kotlin 1.5.15 extension, and Java 17 targets while keeping pull refresh imports valid
- add the missing `fillMaxSize` modifier import in `MainActivity`
- switch the home skeleton placeholder to the official AndroidX API with the required opt-in annotations

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd20c8cf5083229dba08b8a953c6e5