### PR TITLE
Ensure refresh state resets after errors

### DIFF
--- a/app/src/main/java/com/example/ambis/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/ambis/home/HomeViewModel.kt
@@ -66,8 +66,11 @@ class HomeViewModel(
     fun refresh(force: Boolean) {
         viewModelScope.launch(ioDispatcher) {
             _refreshing.value = true
-            fetchData(force)
-            _refreshing.value = false
+            try {
+                fetchData(force)
+            } finally {
+                _refreshing.value = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- guard the refresh coroutine with a try/finally so the refreshing flag is always cleared even when fetchData fails

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d0f5555d208322bba278714e98393c