### PR TITLE
Add Compose foundation android dependency for placeholders

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation-android")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.compose.material:material-pull-refresh")
 


### PR DESCRIPTION
## Summary
- add the Android-specific Compose foundation dependency to provide placeholder APIs

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_b_68d105da8cfc8322a3f285d0d7928555