### PR TITLE
Remove placeholder shimmer from home skeleton

### DIFF
--- a/app/src/main/java/com/example/ambis/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/ambis/home/HomeScreen.kt
@@ -26,9 +26,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.placeholder.PlaceholderHighlight
-import androidx.compose.foundation.placeholder.placeholder
-import androidx.compose.foundation.placeholder.shimmer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.AccountCircle
@@ -551,7 +548,6 @@ private fun HomeSkeleton() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(160.dp)
-                    .placeholder(visible = true, highlight = PlaceholderHighlight.shimmer())
             ) {}
         }
     }


### PR DESCRIPTION
## Summary
- remove the Compose placeholder imports that are unavailable in the current toolchain
- drop the shimmer placeholder usage from the Home skeleton card so the file compiles

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d109d1bc588322abdd5832859e3202