### PR TITLE
Fix Compose pull refresh dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.foundation:foundation-android")
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("androidx.compose.material:material-pull-refresh")
+    implementation("androidx.compose.material3:material3-pullrefresh")
 
     // Debug tooling
     debugImplementation("androidx.compose.ui:ui-tooling")


### PR DESCRIPTION
## Summary
- replace the invalid `androidx.compose.material:material-pull-refresh` dependency with the official Material 3 pull refresh artifact
- ensure Compose dependencies continue to use the 2024.09.02 BOM without explicit versions

## Testing
- ./gradlew help

------
https://chatgpt.com/codex/tasks/task_b_68d11c6b28fc832283fa29f4cb1d55c6