### PR TITLE
Update toolchain to resolve dependency downloads

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.android.application") version "8.5.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 19 14:24:46 WIB 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- upgrade the Android Gradle plugin and Kotlin Gradle plugin to versions compatible with recent Compose artifacts
- bump the Gradle wrapper to 8.7 to satisfy the requirements of the newer Android Gradle plugin

## Testing
- `./gradlew --version` *(fails in the container because the Gradle 8.7 distribution cannot be downloaded due to HTTP 403 from services.gradle.org)*

------
https://chatgpt.com/codex/tasks/task_b_68d125612a188322842a5c2f91685169